### PR TITLE
Add support for different service types, exposed nodes, node replication and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,11 @@ geth:
   # you can find suitable tags in https://hub.docker.com/r/ethereum/client-go/tags/
   # due to some config file changes in geth it needs to be > 1.8.0
   version: stable
-  # network id (1 is mainnet)
-  networkId: 1101
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
   # hex value of initial difficulty defined in the genesis block
   difficulty: "0x400"
   # as it is a private cluster, provide a CIDR of the cluster's network

--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
 # kuberneteth
 deploy a private [ethereum](https://ethereum.org/) blockchain network with kubernetes
 
+another detailed guide can be found on [medium.com](https://medium.com/@cryptoctl/leveraging-kubernetes-to-run-a-private-production-ready-ethereum-network-b6f9b49098df)
+
 ## infrastructure
 the manifest produced by [kuberneteth](./kuberneteth) should work on any platform where kubernetes is up and running.
 
 Make sure to have kubernetes up and running, e.g. via the [official documentation](https://kubernetes.io/docs/setup/pick-right-solution/)
+
+## deployment and cluster setup
+the deployment of the ethereum network nodes happens via the `deployment.yaml` file that is created when calling the [kuberneteth](./kuberneteth) script
+
+the deployment will set up a [geth](https://github.com/ethereum/go-ethereum) cluster consisting of:
+
+* a [bootnode](https://github.com/ethereum/go-ethereum/wiki/Setting-up-private-network-or-local-cluster#setup-bootnode)
+* genesis node (that writes the genesis block initially) - and starts to run normally afterwards
+* miner node(s) (depending on the configuration in [kuberneteth.yaml](./kuberneteth.yaml))
+* member node(s) (depending on the configuration in [kuberneteth.yaml](./kuberneteth.yaml))
+* a monitor to watch the status of the cluster (via [ethereum-netstats](https://github.com/cubedro/eth-netstats) and [eth-net-intelligence-api](https://github.com/cubedro/eth-net-intelligence-api))
+
+## limitations
+* persistent storage of blocks and any data that is usually in the `datadir` (like `.ethereum`) is done via [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) -> make sure to keep it clean, as it is not managed
+* depending on the workers (cpu) the mining time may vary
 
 ## configuration
 the deployment can be configured on a high level via a yaml file [kuberneteth.yaml](kuberneteth.yaml)
@@ -75,21 +92,6 @@ geth:
   # general verbosity of geth [1..5]
   verbosity: 3
 ```
-
-## deployment and cluster setup
-the deployment of the ethereum network nodes happens via the `deployment.yaml` file that is created when calling the [kuberneteth](./kuberneteth) script
-
-the deployment will set up a [geth](https://github.com/ethereum/go-ethereum) cluster consisting of:
-
-* a [bootnode](https://github.com/ethereum/go-ethereum/wiki/Setting-up-private-network-or-local-cluster#setup-bootnode)
-* genesis node (that writes the genesis block initially) - and starts to run normally afterwards
-* miner node(s) (depending on the configuration in [kuberneteth.yaml](./kuberneteth.yaml))
-* member node(s) (depending on the configuration in [kuberneteth.yaml](./kuberneteth.yaml))
-* a monitor to watch the status of the cluster (via [ethereum-netstats](https://github.com/cubedro/eth-netstats) and [eth-net-intelligence-api](https://github.com/cubedro/eth-net-intelligence-api))
-
-## limitations
-* persistent storage of blocks and any data that is usually in the `datadir` (like `.ethereum`) is done via [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) -> make sure to keep it clean, as it is not managed
-* depending on the workers (cpu) the mining time may vary
 
 ## workflow
 once the kubernetes cluster is up and healthy (verify via `kubectl cluster-info`), you can deploy the geth cluster via the following sequence:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ keystore:
 # generic geth related options
 geth:
   # you can find suitable tags in https://hub.docker.com/r/ethereum/client-go/tags/
+  # due to some config file changes in geth it needs to be > 1.8.0
   version: stable
   # network id (1 is mainnet)
   networkId: 1101

--- a/deployment.yaml.erb
+++ b/deployment.yaml.erb
@@ -2,19 +2,22 @@
 # insert readiness checks
 <%
 def set_node_template_vars(values)
-  @Eth_Etherbase         = values["geth"]["Eth_Etherbase"]
-  @Eth_MinerThreads      = values["geth"]["Eth_MinerThreads"]
-  @Node_UserIdent        = values["geth"]["Node_UserIdent"]
-  @Node_DataDir          = values["geth"]["Node_DataDir"]
-  @Node_HTTPPort         = values["geth"]["Node_HTTPPort"]
-  @Node_WSPort           = values["geth"]["Node_WSPort"]
-  @NodeP2P_ListenAddr    = values["geth"]["NodeP2P_ListenAddr"]
-  @NodeP2P_DiscoveryAddr = values["geth"]["NodeP2P_DiscoveryAddr"]
-  @Dashboard_Port        = values["geth"]["Dashboard_Port"]
-  @Dashboard_Refresh     = values["geth"]["Dashboard_Refresh"]
-  @nodePort_rpc          = values["k8s"]["nodePort_rpc"]
-  @nodePort_ipc          = values["k8s"]["nodePort_ipc"]
-  @replicas              = values["k8s"]["replicas"]
+  @replicate              = values["replicate"]
+  @exposed                = values["exposed"]
+  @metrics                = values["geth"]["metrics"]
+  @Eth_Etherbase          = values["geth"]["Eth_Etherbase"]
+  @Eth_MinerThreads       = values["geth"]["Eth_MinerThreads"]
+  @Node_UserIdent         = values["geth"]["Node_UserIdent"]
+  @Node_DataDir           = values["geth"]["Node_DataDir"]
+  @Node_HTTPPort          = values["geth"]["Node_HTTPPort"]
+  @Node_WSPort            = values["geth"]["Node_WSPort"]
+  @NodeP2P_ListenAddr     = values["geth"]["NodeP2P_ListenAddr"]
+  @NodeP2P_DiscoveryAddr  = values["geth"]["NodeP2P_DiscoveryAddr"]
+  @Dashboard_Port         = values["geth"]["Dashboard_Port"]
+  @Dashboard_Refresh      = values["geth"]["Dashboard_Refresh"]
+  @nodePort_rpc           = values["k8s"]["nodePort_rpc"]
+  @nodePort_ipc           = values["k8s"]["nodePort_ipc"]
+  @replicas               = values["k8s"]["replicas"]
   return
 end
 -%>
@@ -34,21 +37,24 @@ data:
     <%= line -%>
 <% end -%>
 <% end -%>
+
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node.values.first) -%>
+<%- (0..@replicate).each do |nodeNumber| -%>
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: gethconfig-<%= @Node_UserIdent %>
+  name: gethconfig-<%= @Node_UserIdent + nodeNumber.to_s %>
   namespace: default
   labels:
     app: kuberneteth
-    name: gethconfig-<%= @Node_UserIdent %>
+    name: gethconfig-<%= @Node_UserIdent + nodeNumber.to_s %>
 data:
   gethconfig: |-
-<%- File.readlines("#{@Node_UserIdent}.toml").each do |line| -%>
+<%- File.readlines("#{@Node_UserIdent}#{nodeNumber}.toml").each do |line| -%>
     <%= line -%>
+<% end -%>
 <% end -%>
 <% end %>
 
@@ -66,8 +72,9 @@ data:
     [
 <%- @nodes.each_with_index do |node, index| -%>
 <%= set_node_template_vars(node.values.first) -%>
+<%- (0..@replicate).each do |nodeNumber| -%>
       {
-        "name"              : "<%= @Node_UserIdent %>",
+        "name"              : "<%= @Node_UserIdent + nodeNumber.to_s %>",
         "cwd"               : ".",
         "script"            : "app.js",
         "log_date_format"   : "YYYY-MM-DD HH:mm Z",
@@ -78,19 +85,20 @@ data:
         "env":
         {
           "NODE_ENV"        : "production",
-          "RPC_HOST"        : "<%= @Node_UserIdent %>-rpchost",
+          "RPC_HOST"        : "<%= @Node_UserIdent + nodeNumber.to_s %>-rpchost",
           "RPC_PORT"        : "<%= @Node_HTTPPort %>",
           "LISTENING_PORT"  : "<%= @NodeP2P_DiscoveryAddr %>",
-          "INSTANCE_NAME"   : "<%= @Node_UserIdent %>",
+          "INSTANCE_NAME"   : "<%= @Node_UserIdent + nodeNumber.to_s %>",
           "CONTACT_DETAILS" : "",
           "WS_SERVER"       : "localhost:3001",
           "WS_SECRET"       : "connectme",
           "VERBOSITY"       : <%= @config["monitor"]["verbosity"] %>
         }
-<%- if index == @nodes.length-1 -%>
+<%- if nodeNumber == @replicate && index == @nodes.length-1 -%>
       }
 <% else -%>
       },
+<% end -%>
 <% end -%>
 <% end -%>
     ]
@@ -116,7 +124,7 @@ data:
         },
         "coinbase" : "0x0000000000000000000000000000000000000000",
         "difficulty" : "<%= @config["geth"]["difficulty"] %>",
-        "extraData" : "0x",
+        "extraData" : "",
         "gasLimit" : "0x47e7c5",
         "nonce" : "0x0000000000000042",
         "mixhash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -129,15 +137,16 @@ data:
 
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node.values.first) -%>
+<%- (0..@replicate).each do |nodeNumber| -%>
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: <%= @Node_UserIdent %>-svc
+  name: <%= @Node_UserIdent + nodeNumber.to_s %>-svc
   labels:
     app: kuberneteth
     tier: backend
-    name: <%= @Node_UserIdent %>-svc
+    name: <%= @Node_UserIdent + nodeNumber.to_s %>-svc
 spec:
   selector:
     app: kuberneteth
@@ -146,33 +155,60 @@ spec:
   type: NodePort
 <% end -%>
   ports:
-    - name: <%= @Node_UserIdent %>-jsonrpc
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-jsonrpc
       protocol: TCP
       port: <%= @Node_HTTPPort %>
       targetPort: <%= @Node_HTTPPort %>
 <%- if @nodePort_rpc -%>
-      nodePort: <%= @nodePort_rpc %>
+      nodePort: <%= @nodePort_rpc + nodeNumber %>
 <% end -%>
-    - name: <%= @Node_UserIdent %>-wsrpc
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-wsrpc
       protocol: TCP
       port: <%= @Node_WSPort %>
       targetPort: <%= @Node_WSPort %>
-    - name: <%= @Node_UserIdent %>-ipc-listen
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-ipc-listen
       protocol: UDP
       port: <%= @NodeP2P_ListenAddr %>
       targetPort: <%= @NodeP2P_ListenAddr %>
-    - name: <%= @Node_UserIdent %>-ipc-discovery
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-ipc-discovery
       protocol: TCP
       port: <%= @NodeP2P_DiscoveryAddr %>
       targetPort: <%= @NodeP2P_DiscoveryAddr %>
 <%- if @nodePort_ipc -%>
-      nodePort: <%= @nodePort_ipc %>
+      nodePort: <%= @nodePort_ipc + nodeNumber %>
 <% end -%>
 <%- if @Dashboard_Port -%>
-    - name: <%= @Node_UserIdent %>-dashboard
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-dashboard
       protocol: TCP
       port: <%= @Dashboard_Port %>
       targetPort: <%= @Dashboard_Port %>
+<% end -%>
+
+<%- if @exposed -%>
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <%= @Node_UserIdent + nodeNumber.to_s %>-web-svc
+  labels:
+    app: kuberneteth
+    tier: backend
+    name: <%= @Node_UserIdent + nodeNumber.to_s %>-web-svc
+spec:
+  selector:
+    app: kuberneteth
+    tier: backend
+  type: LoadBalancer
+  ports:
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-jsonrpc
+      protocol: TCP
+      port: <%= @Node_HTTPPort %>
+      targetPort: <%= @Node_HTTPPort %>
+    - name: <%= @Node_UserIdent + nodeNumber.to_s %>-wsrpc
+      protocol: TCP
+      port: <%= @Node_WSPort %>
+      targetPort: <%= @Node_WSPort %>
+<% end -%>
 <% end -%>
 <% end -%>
 
@@ -284,26 +320,27 @@ spec:
 
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node.values.first) -%>
+<%- (0..@replicate).each do |nodeNumber| -%>
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: geth-<%= @Node_UserIdent %>-deployment
+  name: geth-<%= @Node_UserIdent + nodeNumber.to_s %>-deployment
 spec:
   strategy:
     type: RollingUpdate
   replicas: <%= @replicas %>
   template:
     metadata:
-      name: geth-<%= @Node_UserIdent %>-deployment
+      name: geth-<%= @Node_UserIdent + nodeNumber.to_s %>-deployment
       labels:
         app: kuberneteth
         tier: backend
-        name: <%= @Node_UserIdent %>-deployment
+        name: <%= @Node_UserIdent + nodeNumber.to_s %>-deployment
     spec:
       initContainers:
 <%- unless @config["geth"]["network"]["public"] -%>
-      - name: <%= @Node_UserIdent %>-genesis-init-container
+      - name: <%= @Node_UserIdent + nodeNumber.to_s %>-genesis-init-container
         image: ethereum/client-go:<%= @config["geth"]["version"] %>
         command: [ "sh" ]
         args:
@@ -313,7 +350,7 @@ spec:
              touch <%= @Node_DataDir %>/genesis_created;
            fi;"
         volumeMounts:
-        - name: <%= @Node_UserIdent %>-persistent-storage
+        - name: <%= @Node_UserIdent + nodeNumber.to_s %>-persistent-storage
           mountPath: <%= @Node_DataDir %>
         - name: geth-boot-node-persistent-storage
           mountPath: <%= @config["bootnode"]["geth"]["Node_DataDir"] %>
@@ -322,18 +359,18 @@ spec:
           subPath: Genesis-geth.json
 <% end -%>
       containers:
-      - name: <%= @Node_UserIdent %>-container
+      - name: <%= @Node_UserIdent + nodeNumber.to_s %>-container
         image: ethereum/client-go:<%= @config["geth"]["version"] %>
         command: [ "sh" ]
         args:
         - "-cx"
-        - "mkdir -p /etc/geth/<%= @Node_UserIdent %>;
-           cp /etc/gethconfigmap/<%= @Node_UserIdent %>/gethconfig.toml /etc/geth/<%= @Node_UserIdent %>;
+        - "mkdir -p /etc/geth/<%= @Node_UserIdent + nodeNumber.to_s %>;
+           cp /etc/gethconfigmap/<%= @Node_UserIdent + nodeNumber.to_s %>/gethconfig.toml /etc/geth/<%= @Node_UserIdent + nodeNumber.to_s %>;
 <%- unless @config["geth"]["network"]["public"] -%>
            ENODE=$(cat <%= @config["bootnode"]["geth"]["Node_DataDir"] %>/enode.address);
            ENODE_ESC=$(echo $ENODE | sed 's@//@\\\\/\\\\/@g');
-           sed -i \"s/BootstrapNodes = \\[\\]/BootstrapNodes = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
-           sed -i \"s/BootstrapNodesV5 = \\[\\]/BootstrapNodesV5 = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
+           sed -i \"s/BootstrapNodes = \\[\\]/BootstrapNodes = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent + nodeNumber.to_s %>/gethconfig.toml;
+           sed -i \"s/BootstrapNodesV5 = \\[\\]/BootstrapNodesV5 = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent + nodeNumber.to_s %>/gethconfig.toml;
 <% end -%>
            /usr/local/bin/geth \
 <%- if @Dashboard_Port || @Dashboard_Refresh -%>
@@ -342,11 +379,14 @@ spec:
 <%- if @Eth_Etherbase && @Eth_MinerThreads -%>
            --mine \
 <% end -%>
+<%- if @metrics -%>
+           --metrics \
+<% end -%>
 <%- unless @config["geth"]["network"]["public"] -%>
            --netrestrict <%= @config["geth"]["NodeP2P_Netrestrict"] %> \
 <% end -%>
            --verbosity <%= @config["geth"]["verbosity"] %>  \
-           --config /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;"
+           --config /etc/geth/<%= @Node_UserIdent + nodeNumber.to_s %>/gethconfig.toml;"
         ports:
           - containerPort: <%= @Node_HTTPPort %>
           - containerPort: <%= @Node_WSPort %>
@@ -357,10 +397,10 @@ spec:
           - containerPort: <%= @Dashboard_Port %>
 <% end -%>
         volumeMounts:
-        - name: <%= @Node_UserIdent %>-persistent-storage
+        - name: <%= @Node_UserIdent + nodeNumber.to_s %>-persistent-storage
           mountPath: <%= @Node_DataDir %>
-        - name: <%= @Node_UserIdent %>-config-persistent-storage
-          mountPath: /etc/gethconfigmap/<%= @Node_UserIdent %>
+        - name: <%= @Node_UserIdent + nodeNumber.to_s %>-config-persistent-storage
+          mountPath: /etc/gethconfigmap/<%= @Node_UserIdent + nodeNumber.to_s %>
         - name: keystore-config-persistent-storage
           mountPath: <%= @Node_DataDir %>/keystore/<%= @config["keystore"]["name"] %>
           subPath: <%= @config["keystore"]["name"] %>
@@ -391,15 +431,16 @@ spec:
           - key: Genesis-geth.json
             path: Genesis-geth.json
 <% end -%>
-      - name: <%= @Node_UserIdent %>-persistent-storage
+      - name: <%= @Node_UserIdent + nodeNumber.to_s %>-persistent-storage
         hostPath:
-          path: /var/lib/docker/geth-storage/<%= @Node_UserIdent %>
-      - name: <%= @Node_UserIdent %>-config-persistent-storage
+          path: /var/lib/docker/geth-storage/<%= @Node_UserIdent + nodeNumber.to_s %>
+      - name: <%= @Node_UserIdent + nodeNumber.to_s %>-config-persistent-storage
         configMap:
-          name: gethconfig-<%= @Node_UserIdent %>
+          name: gethconfig-<%= @Node_UserIdent + nodeNumber.to_s %>
           items:
           - key: gethconfig
             path: gethconfig.toml
+<% end -%>
 <% end -%>
 
 ---
@@ -415,16 +456,19 @@ spec:
   selector:
     app: kuberneteth
     tier: frontend
-<%- if @config["monitor"]["nodePort"] -%>
-  type: NodePort
-<% end -%>
+  type: <%= @config["monitor"]["serviceType"] %>
   ports:
     - name: <%= @config["monitor"]["name"] %>-port
       protocol: TCP
+      <%- case @config["monitor"]["serviceType"] when "ClusterIP" -%>
       port: 3001
-<%- if @config["monitor"]["nodePort"] -%>
-      nodePort: <%= @config["monitor"]["nodePort"] %>
-<% end -%>
+      <%- when "NodePort" -%>
+      port: 3001
+      targetPort: 3001
+      <%- when "LoadBalancer" -%>
+      port: 80
+      targetPort: 3001
+      <%- end -%>
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -452,7 +496,9 @@ spec:
            cp /monitor-configmap/app.json /ethmonitor/app.json;
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node.values.first) -%>
-           sed -i \"s/<%= @Node_UserIdent %>-rpchost/$<%= @Node_UserIdent.upcase %>_SVC_SERVICE_HOST/g\" /ethmonitor/app.json;
+<%- (0..@replicate).each do |nodeNumber| -%>
+           sed -i \"s/<%= @Node_UserIdent + nodeNumber.to_s %>-rpchost/$<%= @Node_UserIdent.upcase + nodeNumber.to_s %>_SVC_SERVICE_HOST/g\" /ethmonitor/app.json;
+<% end -%>
 <% end -%>
            exit 0;"
         volumeMounts:

--- a/deployment.yaml.erb
+++ b/deployment.yaml.erb
@@ -315,27 +315,19 @@ spec:
         - name: genesis-config-persistent-storage
           mountPath: /etc/geth/genesis/Genesis-geth.json
           subPath: Genesis-geth.json
-      - name: <%= @Node_UserIdent %>-init-container
-        image: ethereum/client-go:<%= @config["geth"]["version"] %>
-        command: [ "sh" ]
-        args:
-        - "-cx"
-        - "ENODE=$(cat <%= @config["bootnode"]["geth"]["Node_DataDir"] %>/enode.address);
-           ENODE_ESC=$(echo $ENODE | sed 's@//@\\\\/\\\\/@g');
-           sed -i \"s/BootstrapNodes = \\[\\]/BootstrapNodes = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
-           sed -i \"s/BootstrapNodesV5 = \\[\\]/BootstrapNodesV5 = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;"
-        volumeMounts:
-        - name: <%= @Node_UserIdent %>-config-persistent-storage
-          mountPath: /etc/geth/<%= @Node_UserIdent %>
-        - name: geth-boot-node-persistent-storage
-          mountPath: <%= @config["bootnode"]["geth"]["Node_DataDir"] %>
       containers:
       - name: <%= @Node_UserIdent %>-container
         image: ethereum/client-go:<%= @config["geth"]["version"] %>
         command: [ "sh" ]
         args:
         - "-cx"
-        - "/usr/local/bin/geth \
+        - "mkdir -p /etc/geth/<%= @Node_UserIdent %>;
+           cp /etc/gethconfigmap/<%= @Node_UserIdent %>/gethconfig.toml /etc/geth/<%= @Node_UserIdent %>;
+           ENODE=$(cat <%= @config["bootnode"]["geth"]["Node_DataDir"] %>/enode.address);
+           ENODE_ESC=$(echo $ENODE | sed 's@//@\\\\/\\\\/@g');
+           sed -i \"s/BootstrapNodes = \\[\\]/BootstrapNodes = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
+           sed -i \"s/BootstrapNodesV5 = \\[\\]/BootstrapNodesV5 = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
+           /usr/local/bin/geth \
 <%- if @Dashboard_Port || @Dashboard_Refresh -%>
            --dashboard \
 <% end -%>
@@ -359,7 +351,7 @@ spec:
         - name: <%= @Node_UserIdent %>-persistent-storage
           mountPath: <%= @Node_DataDir %>
         - name: <%= @Node_UserIdent %>-config-persistent-storage
-          mountPath: /etc/geth/<%= @Node_UserIdent %>
+          mountPath: /etc/gethconfigmap/<%= @Node_UserIdent %>
         - name: keystore-config-persistent-storage
           mountPath: <%= @Node_DataDir %>/keystore/<%= @config["keystore"]["name"] %>
           subPath: <%= @config["keystore"]["name"] %>

--- a/deployment.yaml.erb
+++ b/deployment.yaml.erb
@@ -336,8 +336,7 @@ spec:
 <% end -%>
            --netrestrict <%= @config["geth"]["NodeP2P_Netrestrict"] %> \
            --verbosity <%= @config["geth"]["verbosity"] %>  \
-           --config /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml \
-           --bootnodes \"$(cat <%= @config["bootnode"]["geth"]["Node_DataDir"] %>/enode.address)\";" # FIXME drop when https://github.com/ethereum/go-ethereum/pull/15557 is at least in the stable version
+           --config /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;"
         ports:
           - containerPort: <%= @Node_HTTPPort %>
           - containerPort: <%= @Node_WSPort %>

--- a/deployment.yaml.erb
+++ b/deployment.yaml.erb
@@ -95,6 +95,7 @@ data:
 <% end -%>
     ]
 
+<%- unless @config["geth"]["network"]["public"] -%>
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -108,7 +109,7 @@ data:
   Genesis-geth.json: |-
     {
         "config": {
-            "chainId": <%= @config["geth"]["networkId"] %>,
+            "chainId": <%= @config["geth"]["network"]["id"] %>,
             "homesteadBlock": 0,
             "eip155Block": 0,
             "eip158Block": 0
@@ -124,6 +125,7 @@ data:
         "alloc" : {
         }
     }
+<% end -%>
 
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node.values.first) -%>
@@ -174,6 +176,7 @@ spec:
 <% end -%>
 <% end -%>
 
+<%- unless @config["geth"]["network"]["public"] -%>
 ---
 apiVersion: v1
 kind: Service
@@ -277,6 +280,7 @@ spec:
       items:
       - key: Genesis-geth.json
         path: Genesis-geth.json
+<% end -%>
 
 <%- @nodes.each do |node| -%>
 <%= set_node_template_vars(node.values.first) -%>
@@ -298,6 +302,7 @@ spec:
         name: <%= @Node_UserIdent %>-deployment
     spec:
       initContainers:
+<%- unless @config["geth"]["network"]["public"] -%>
       - name: <%= @Node_UserIdent %>-genesis-init-container
         image: ethereum/client-go:<%= @config["geth"]["version"] %>
         command: [ "sh" ]
@@ -315,6 +320,7 @@ spec:
         - name: genesis-config-persistent-storage
           mountPath: /etc/geth/genesis/Genesis-geth.json
           subPath: Genesis-geth.json
+<% end -%>
       containers:
       - name: <%= @Node_UserIdent %>-container
         image: ethereum/client-go:<%= @config["geth"]["version"] %>
@@ -323,10 +329,12 @@ spec:
         - "-cx"
         - "mkdir -p /etc/geth/<%= @Node_UserIdent %>;
            cp /etc/gethconfigmap/<%= @Node_UserIdent %>/gethconfig.toml /etc/geth/<%= @Node_UserIdent %>;
+<%- unless @config["geth"]["network"]["public"] -%>
            ENODE=$(cat <%= @config["bootnode"]["geth"]["Node_DataDir"] %>/enode.address);
            ENODE_ESC=$(echo $ENODE | sed 's@//@\\\\/\\\\/@g');
            sed -i \"s/BootstrapNodes = \\[\\]/BootstrapNodes = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
            sed -i \"s/BootstrapNodesV5 = \\[\\]/BootstrapNodesV5 = [\\\"$ENODE_ESC\\\"]/g\" /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;
+<% end -%>
            /usr/local/bin/geth \
 <%- if @Dashboard_Port || @Dashboard_Refresh -%>
            --dashboard \
@@ -334,7 +342,9 @@ spec:
 <%- if @Eth_Etherbase && @Eth_MinerThreads -%>
            --mine \
 <% end -%>
+<%- unless @config["geth"]["network"]["public"] -%>
            --netrestrict <%= @config["geth"]["NodeP2P_Netrestrict"] %> \
+<% end -%>
            --verbosity <%= @config["geth"]["verbosity"] %>  \
            --config /etc/geth/<%= @Node_UserIdent %>/gethconfig.toml;"
         ports:
@@ -354,12 +364,11 @@ spec:
         - name: keystore-config-persistent-storage
           mountPath: <%= @Node_DataDir %>/keystore/<%= @config["keystore"]["name"] %>
           subPath: <%= @config["keystore"]["name"] %>
+<%- unless @config["geth"]["network"]["public"] -%>
         - name: geth-boot-node-persistent-storage
           mountPath: <%= @config["bootnode"]["geth"]["Node_DataDir"] %>
+<% end -%>
       volumes:
-      - name: geth-boot-node-persistent-storage
-        hostPath:
-          path: /var/lib/docker/geth-storage/bootnode
       - name: keystore-config-persistent-storage
 <%- if @config["keystore"]["secret"] -%>
         secret:
@@ -371,12 +380,17 @@ spec:
           - key: <%= @config["keystore"]["name"] %>
             path: <%= @config["keystore"]["name"] %>
 <% end -%>
+<%- unless @config["geth"]["network"]["public"] -%>
+      - name: geth-boot-node-persistent-storage
+        hostPath:
+          path: /var/lib/docker/geth-storage/bootnode
       - name: genesis-config-persistent-storage
         configMap:
           name: genesis-config
           items:
           - key: Genesis-geth.json
             path: Genesis-geth.json
+<% end -%>
       - name: <%= @Node_UserIdent %>-persistent-storage
         hostPath:
           path: /var/lib/docker/geth-storage/<%= @Node_UserIdent %>

--- a/kuberneteth
+++ b/kuberneteth
@@ -12,6 +12,8 @@ require "erb"
 #####################
 
 def set_node_template_vars(values)
+  @replicate             = values["replicate"]
+  @exposed               = values["exposed"]
   @Eth_Etherbase         = values["geth"]["Eth_Etherbase"]
   @Eth_MinerThreads      = values["geth"]["Eth_MinerThreads"]
   @Node_UserIdent        = values["geth"]["Node_UserIdent"]
@@ -30,9 +32,12 @@ end
 
 @nodes.each do |node|
   set_node_template_vars(node.values.first)
+  (0..@replicate).each do |nodeNumber|
+    @NodeNumber = nodeNumber
 
-  File.open("#{@Node_UserIdent}.toml", "w") do |f|
-    f.puts (ERB.new(File.read("node.toml.erb"), nil, "-").result)
+    File.open("#{@Node_UserIdent}#{@NodeNumber}.toml", "w") do |f|
+      f.puts (ERB.new(File.read("node.toml.erb"), nil, "-").result)
+    end
   end
 end
 

--- a/kuberneteth.yaml
+++ b/kuberneteth.yaml
@@ -51,6 +51,7 @@ keystore:
 # generic geth related options
 geth:
   # you can find suitable tags in https://hub.docker.com/r/ethereum/client-go/tags/
+  # due to some config file changes in geth it needs to be > 1.8.0
   version: stable
   # network id (1 is mainnet)
   networkId: 1101

--- a/kuberneteth.yaml
+++ b/kuberneteth.yaml
@@ -53,8 +53,11 @@ geth:
   # you can find suitable tags in https://hub.docker.com/r/ethereum/client-go/tags/
   # due to some config file changes in geth it needs to be > 1.8.0
   version: stable
-  # network id (1 is mainnet)
-  networkId: 1101
+  network:
+    # network id (1: mainnet, 3: ropsten, 4: rinkeby ... )
+    id: 1101
+    # public (true|false) is it a public network?
+    public: false
   # hex value of initial difficulty defined in the genesis block
   difficulty: "0x400"
   # as it is a private cluster, provide a CIDR of the cluster's network

--- a/kuberneteth.yaml
+++ b/kuberneteth.yaml
@@ -11,18 +11,27 @@ bootnode:
 # here you can add as many nodes as you like, name and configure them
 nodes:
 - miner:
+    # the number of extra instances of this node you want to create [0 or more]
+    replicate: 0
+    # [true or false] If true a LoadBalancer will be created with an external facing IP
+    exposed: false
     # this config values will end up in the k8s manifest directly
     k8s:
       # open a port on each node (optional)
-      nodePort_rpc: 30001
-      nodePort_ipc: 30002
+      # if replicate is > 0 these numbers will be incremented for each extra instance
+      # note: if replicate >= 1000 there will be collisions
+      nodePort_rpc: 30000
+      nodePort_ipc: 31000
       replicas: 1
     # this config values will alter the geth config toml file which will end up as a ConfigMap in the k8s manifest
     geth:
+      # if set then metrics will be enabled on the node.
+      metrics: false
       # address where the mining rewards will go to (optional)
       Eth_Etherbase: "0x023e291a99d21c944a871adcc44561a58f99bdbc"
       # threads (optional)
       Eth_MinerThreads: 1
+      # this name will be appened by the node replicated number e.g. miner0
       Node_UserIdent: miner
       Node_DataDir: /etc/testnet/miner
       Node_HTTPPort: 8545
@@ -37,10 +46,13 @@ nodes:
 # ...
 monitor:
   name: monitor
+  # type can be [ClusterIP, NodePort, LoadBalancer]
+  serviceType: LoadBalancer
   # verbosity can be within [0..3]
   verbosity: 0
   k8s:
-    nodePort: 30007
+    # make sure this nodePort is not the same as any of the nodes nodePorts
+    nodePort: 32000
 # create a private key and add it to the keystore folder
 # ... or just use the example one for testing
 keystore:

--- a/node.toml.erb
+++ b/node.toml.erb
@@ -40,7 +40,7 @@ MaxMessageSize = 1048576
 MinimumAcceptedPOW = 2e-01
 
 [Node]
-UserIdent = "<%= @Node_UserIdent %>"
+UserIdent = "<%= @Node_UserIdent + @NodeNumber.to_s %>"
 DataDir = "<%= @Node_DataDir %>"
 IPCPath = "<%= @Node_DataDir %>/geth.ipc"
 HTTPHost = "0.0.0.0"

--- a/node.toml.erb
+++ b/node.toml.erb
@@ -8,13 +8,16 @@ Etherbase = "<%= @Eth_Etherbase %>"
 MinerThreads = <%= @Eth_MinerThreads %>
 <% end -%>
 GasPrice = 18000000000
-EthashCacheDir = "ethash"
-EthashCachesInMem = 2
-EthashCachesOnDisk = 3
-EthashDatasetDir = "/root/.ethash"
-EthashDatasetsInMem = 1
-EthashDatasetsOnDisk = 2
 EnablePreimageRecording = false
+
+[Eth.Ethash]
+CacheDir = "ethash"
+CachesInMem = 2
+CachesOnDisk = 3
+DatasetDir = "/root/.ethash"
+DatasetsInMem = 1
+DatasetsOnDisk = 2
+PowMode = 0
 
 [Eth.TxPool]
 NoLocals = false
@@ -43,6 +46,7 @@ IPCPath = "<%= @Node_DataDir %>/geth.ipc"
 HTTPHost = "0.0.0.0"
 HTTPPort = <%= @Node_HTTPPort %>
 HTTPCors = ["*"]
+HTTPVirtualHosts = ["*"]
 HTTPModules = ["db", "eth", "net", "web3", "personal", "web3"]
 WSHost = "0.0.0.0"
 WSPort = <%= @Node_WSPort %>
@@ -51,7 +55,6 @@ WSModules = ["net", "web3", "eth", "shh"]
 [Node.P2P]
 MaxPeers = 25
 NoDiscovery = false
-DiscoveryV5Addr = ":30304"
 BootstrapNodes = []
 BootstrapNodesV5 = []
 StaticNodes = []

--- a/node.toml.erb
+++ b/node.toml.erb
@@ -1,5 +1,5 @@
 [Eth]
-NetworkId = <%= @config["geth"]["networkId"] %>
+NetworkId = <%= @config["geth"]["network"]["id"] %>
 SyncMode = "fast"
 LightPeers = 20
 DatabaseCache = 128
@@ -55,8 +55,10 @@ WSModules = ["net", "web3", "eth", "shh"]
 [Node.P2P]
 MaxPeers = 25
 NoDiscovery = false
+<%- unless @config["geth"]["network"]["public"] -%>
 BootstrapNodes = []
 BootstrapNodesV5 = []
+<% end -%>
 StaticNodes = []
 TrustedNodes = []
 ListenAddr = ":<%= @NodeP2P_DiscoveryAddr %>"


### PR DESCRIPTION
This PR allows for duplicates of a node config to be made from the kubereneteth.yaml along with adding the option to expose a node using a LoadBalancer and to enable geth metrics on the node.